### PR TITLE
githubコマンドの暫定追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 Requests
 coloredlogs
 google-api-python-client
+requests

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -40,6 +40,10 @@ class App:
         async def show_info(ctx):
             await self.controller.searchResult(ctx)
 
+        @bot.command(name=cmdName('github', self.is_dev))
+        async def show_info(ctx):
+            await self.controller.githubResult(ctx)
+
         @bot.event
         async def on_command_error(ctx, e):
             cmd = ctx.invoked_with

--- a/src/app/controllers/message_controller.py
+++ b/src/app/controllers/message_controller.py
@@ -29,7 +29,7 @@ class MessageController:
     async def githubResult(self, ctx):
         try:
             results = self.model.getGitHubActivity()
-            await self.view.sendGitHubActivity(ctx, results)
+            await self.view.sendGithubActivity(ctx, results)
 
         except Exception as e:
             await ctx.send("取得に失敗しました")

--- a/src/app/controllers/message_controller.py
+++ b/src/app/controllers/message_controller.py
@@ -25,3 +25,11 @@ class MessageController:
         except Exception as e:
             logger.error(f"Error: {e}")
             await ctx.send('取得に失敗しました')
+
+    async def githubResult(self, ctx):
+        try:
+            results = self.model.getGitHubActivity()
+            await self.view.sendGitHubActivity(ctx, results)
+
+        except Exception as e:
+            await ctx.send("取得に失敗しました")

--- a/src/app/models/message_model.py
+++ b/src/app/models/message_model.py
@@ -1,5 +1,6 @@
 import os
 import json
+import requests
 from dotenv import load_dotenv
 from logging import getLogger
 from googleapiclient.discovery import build
@@ -9,17 +10,20 @@ logger = getLogger(__name__)
 class MessageModel:
     def __init__(self):
         load_dotenv()
-        self.API_KEY = os.getenv("GOOGLE_API_KEY")
-        self.ENGINE_ID = os.getenv("SEARCH_ENGINE_ID")
+        self.GOOGLE_SEARCH_API_KEY = os.getenv("GOOGLE_SEARCH_API_KEY")
+        self.GOOGLE_SEARCH_ENGINE_ID = os.getenv("GOOGLE_SEARCH_ENGINE_ID")
+        self.GITHUB_USERNAME = os.getenv("3K1_GIT_USERNAME")
+        self.GITHUB_API_TOKEN = os.getenv("GITHUB_API_TOKEN")
+        self.GITHUB_API_URL = f"https://api.github.com/users/{self.GITHUB_USERNAME}/events"
 
     def getSearchResponse(self, query):
-        service = build("customsearch", "v1", developerKey=self.API_KEY)
+        service = build("customsearch", "v1", developerKey=self.GOOGLE_SEARCH_API_KEY)
         try:
             response = (
                 service.cse()
                 .list(
                     q=query,
-                    cx=self.ENGINE_ID,
+                    cx=self.GOOGLE_SEARCH_ENGINE_ID,
                     lr='lang_ja',
                     filter=0,
                     num=10,
@@ -32,5 +36,29 @@ class MessageModel:
 
         results = response["items"]
         logger.info(f"Number of results: {response["searchInformation"]["totalResults"]}")
+
+        return results
+
+    def getGitHubActivity(self):
+        print(self.GITHUB_API_URL)
+        url = self.GITHUB_API_URL
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {self.GITHUB_API_TOKEN}",
+            "X-GitHub-Api-Version": "2022-11-28"
+        }
+        params = {
+            "per_page": 10,
+            "page": 1
+        }
+
+        try:
+            response = requests.get(url=url, headers=headers, params=params)
+            response.raise_for_status()
+            results = json.loads(response.text)
+            # print(f"type: {results[0]["type"]}, name: {results[0]["payload"]["forkee"]["name"]}, full_name: {results[0]["payload"]["forkee"]["full_name"]}")
+        except Exception as e:
+            logger.error(e)
+            raise Exception("Request error.")
 
         return results

--- a/src/app/models/message_model.py
+++ b/src/app/models/message_model.py
@@ -48,7 +48,7 @@ class MessageModel:
             "X-GitHub-Api-Version": "2022-11-28"
         }
         params = {
-            "per_page": 10,
+            "per_page": 30,
             "page": 1
         }
 

--- a/src/app/views/discord_view.py
+++ b/src/app/views/discord_view.py
@@ -29,6 +29,8 @@ class DiscordView:
             await ctx.send(f"GitHubのアクティビティ: {len(results)}件")
             for result in results:
                 match result["type"]:
+                    case "CreateEvent":
+                        embedMsg = parseGitHubCreateEvent(result)
                     case "PushEvent":
                         embedMsg = parseGitHubPushEvent(result)
                     case "ForkEvent":
@@ -47,6 +49,16 @@ class DiscordView:
         except Exception as e:
             logger.error(f"Error: {e}")
             await ctx.send("取得に失敗しました")
+
+def parseGitHubCreateEvent(data):
+    embedMsg = discord.Embed(
+        title=data["repo"]["name"],
+        description=f"リポジトリ{data["repo"]["name"]}を作成しました",
+        url=f"https://github.com/{data["repo"]["name"]}",
+        color=discord.Colour.green()
+    )
+
+    return embedMsg
 
 def parseGitHubPushEvent(data):
     commits_string = ""

--- a/src/app/views/discord_view.py
+++ b/src/app/views/discord_view.py
@@ -23,3 +23,53 @@ class DiscordView:
         except Exception as e:
             logger.error(f"Error: {e}")
             await ctx.send('取得に失敗しました')
+
+    async def sendGitHubActivity(self, ctx, results):
+        try:
+            await ctx.send(f"GitHubのアクティビティ: {len(results)}件")
+            for result in results:
+                match result["type"]:
+                    case "PushEvent":
+                        embedMsg = parseGitHubPushEvent(result)
+                    case "ForkEvent":
+                        embedMsg = parseGitHubForkEvent(result)
+                        pass
+                    case _:
+                        embedMsg = discord.Embed(
+                            title=result["type"],
+                            url=result["repo"]["url"],
+                            color=discord.Colour.green()
+                        )
+                        pass
+
+                embedMsg.set_thumbnail(url=result["actor"]["avatar_url"])
+                await ctx.send(embed=embedMsg)
+        except Exception as e:
+            logger.error(f"Error: {e}")
+            await ctx.send("取得に失敗しました")
+
+def parseGitHubPushEvent(data):
+    commits_string = ""
+    for commit in data["payload"]["commits"]:
+        commits_string += f"- {commit["message"]},\n"
+    commits_string = commits_string[:-2]
+    embedMsg = discord.Embed(
+        title=data["repo"]["name"],
+        description=f"\
+            pushしました\n\
+            {commits_string}",
+        url=f"https://github.com/{data["repo"]["name"]}",
+        color=discord.Colour.green()
+    )
+
+    return embedMsg
+
+def parseGitHubForkEvent(data):
+    embedMsg = discord.Embed(
+        title=data["payload"]["forkee"]["full_name"],
+        description=f"{data["repo"]["name"]}をforkしました",
+        url=f"https://github.com/{data["payload"]["forkee"]["full_name"]}",
+        color=discord.Colour.green()
+    )
+
+    return embedMsg

--- a/src/app/views/discord_view.py
+++ b/src/app/views/discord_view.py
@@ -24,17 +24,20 @@ class DiscordView:
             logger.error(f"Error: {e}")
             await ctx.send('取得に失敗しました')
 
-    async def sendGitHubActivity(self, ctx, results):
+    async def sendGithubActivity(self, ctx, results):
         try:
             await ctx.send(f"GitHubのアクティビティ: {len(results)}件")
             for result in results:
                 match result["type"]:
                     case "CreateEvent":
-                        embedMsg = parseGitHubCreateEvent(result)
+                        embedMsg = parseGithubCreateEvent(result)
                     case "PushEvent":
-                        embedMsg = parseGitHubPushEvent(result)
+                        embedMsg = parseGithubPushEvent(result)
                     case "ForkEvent":
-                        embedMsg = parseGitHubForkEvent(result)
+                        embedMsg = parseGithubForkEvent(result)
+                        pass
+                    case "IssuesEvent":
+                        embedMsg = parseGithubIssuesEvent(result)
                         pass
                     case _:
                         embedMsg = discord.Embed(
@@ -50,7 +53,7 @@ class DiscordView:
             logger.error(f"Error: {e}")
             await ctx.send("取得に失敗しました")
 
-def parseGitHubCreateEvent(data):
+def parseGithubCreateEvent(data):
     embedMsg = discord.Embed(
         title=data["repo"]["name"],
         description=f"リポジトリ{data["repo"]["name"]}を作成しました",
@@ -60,7 +63,7 @@ def parseGitHubCreateEvent(data):
 
     return embedMsg
 
-def parseGitHubPushEvent(data):
+def parseGithubPushEvent(data):
     commits_string = ""
     for commit in data["payload"]["commits"]:
         commits_string += f"- {commit["message"]},\n"
@@ -76,11 +79,33 @@ def parseGitHubPushEvent(data):
 
     return embedMsg
 
-def parseGitHubForkEvent(data):
+def parseGithubForkEvent(data):
     embedMsg = discord.Embed(
         title=data["payload"]["forkee"]["full_name"],
         description=f"{data["repo"]["name"]}をforkしました",
         url=f"https://github.com/{data["payload"]["forkee"]["full_name"]}",
+        color=discord.Colour.green()
+    )
+
+    return embedMsg
+
+def parseGithubIssuesEvent(data):
+    ACTIONS = {
+        "opened": "オープン",
+        "edited": "変更",
+        "closed": "クローズ",
+        "reopend": "再オープン",
+        "assigned": "アサイン",
+        "unassigned": "アサイン解除",
+        "labeled": "ラベル付与",
+        "unlabeled": "ラベル削除"
+    }
+    embedMsg = discord.Embed(
+        title=data["repo"]["name"],
+        description=f"\
+            Issueを{ACTIONS[data["payload"]["action"]]}しました\n\
+            [{data["payload"]["issue"]["title"]}]({data["payload"]["issue"]["html_url"]})",
+        url=f"https://github.com/{data["repo"]["name"]}",
         color=discord.Colour.green()
     )
 


### PR DESCRIPTION
## 概要

まん３のGitHub アクティビティを取得する`$github` コマンドを追加する #3 
とりあえずの暫定仕様

## 実装詳細

- 一旦は取得できた結果を全て返す
- 名前が変更されたリポジトリは追跡できない
- 一部のイベントのみ対応
  - CreateEvent
  - ForkEvent
  - IssuesEvent
  - PushEvent

## 参考

[List events for the authenticated user](https://docs.github.com/ja/rest/activity/events?apiVersion=2022-11-28#list-events-for-the-authenticated-user)
[GitHubイベントの種類](https://docs.github.com/ja/rest/using-the-rest-api/github-event-types?apiVersion=2022-11-28#event-object-common-properties)
